### PR TITLE
Fix for Maya2015 (prevent crash at load time)

### DIFF
--- a/intallfiles_FullKit/lbs_Custom_Tools_UI_LOCAL.mel
+++ b/intallfiles_FullKit/lbs_Custom_Tools_UI_LOCAL.mel
@@ -318,7 +318,9 @@ string $scriptLoc = "/Users/User_Account/Library/Preferences/Autodesk/maya/scrip
 	tabLayout -e
 		-tl flowerOfLifeForm "F.O.L." winTab;
 
-	windowPref -r lbs_scriptsWindow;
+	if (`windowPref -exists lbs_scriptsWindow`) {
+		windowPref -r lbs_scriptsWindow;
+	}
 	window -e -h 740 -w 510 lbs_scriptsWindow;
 	tabLayout -e -h 740 -w 510 winTab;
 	torus_textListCheck;


### PR DESCRIPTION
Well, it basically just prevent crashing when displaying the tools in Maya 2015.
