### PR TITLE
updated windows install instructions and fixed lbs_scriptsWin name

### DIFF
--- a/Phi_Tab/PhiToolkit.mel
+++ b/Phi_Tab/PhiToolkit.mel
@@ -174,7 +174,7 @@ proc phi_creation(int $phiGrpNum, int $nCurves, float $sNode, float $pNode, int 
 		xform -os -piv 0 0 0;
 		rename $phiGrp phiCurve_Grp;
 
-		rename $phiCurve "phiCurveGrp_1";
+		rename $phiCurve phiCurveGrp_1;
 		$phiCurve = "phiCurveGrp_1";
 	}
 

--- a/Phi_Tab/PhiToolkit.mel
+++ b/Phi_Tab/PhiToolkit.mel
@@ -174,7 +174,7 @@ proc phi_creation(int $phiGrpNum, int $nCurves, float $sNode, float $pNode, int 
 		xform -os -piv 0 0 0;
 		rename $phiGrp phiCurve_Grp;
 
-		rename $phiCurve phiCurveGrp_1;
+		rename $phiCurve "phiCurveGrp_1";
 		$phiCurve = "phiCurveGrp_1";
 	}
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ Install Instructions
 
   For Mac users, the Maya scripts folder is:    HD/Users/User_Account/Library/Preferences/Autodesk/maya/scripts
 
-  For Windows users:                            C:\Documents and Settings\User_Account\My Documents\maya\scripts
+  For Windows users:                            C:/Documents and Settings/User_Account/My Documents/maya/scripts
 
 3) Using a text editor, modify the following two lines from the lbsToolMenuFull.mel & miniKit.mel files, replacing "User_Account" with the path appropriate for your file system.
 
-For Mac users, it's a simple name change.  For Windows users, you may need to add "C:\" and adjust the "/" to "\". 
+For Mac users, it's a simple name change.  For Windows users, you may need to add absolute path including "C:/" (use forward slashes). 
 
 	  menuItem -p $MyMenuObj -l "mini kit" -c ("source \"/Users/User_Account/Library/Preferences/Autodesk/maya/scripts/lbsToolkit/toolkit_dropDown/miniKit.mel\"; ");
 	  menuItem -p $MyMenuObj -l "full kit" -c ("source \"/Users/User_Account/Library/Preferences/Autodesk/maya/scripts/lbsToolkit/lbs_Custom_Tools_UI_LOCAL.mel\"; ");

--- a/intallfiles_FullKit/lbs_Custom_Tools_UI_LOCAL.mel
+++ b/intallfiles_FullKit/lbs_Custom_Tools_UI_LOCAL.mel
@@ -124,7 +124,7 @@ string $scriptLoc = "/Users/User_Account/Library/Preferences/Autodesk/maya/scrip
 
 	if(`window -ex lbs_scriptsWindow`) deleteUI lbs_scriptsWindow;
 
-	$lbs_scriptWin = `window 
+	$lbs_scriptsWindow = `window 
 		-title "liquidbuddha.studios - Custom Tools" 
 		-s 1
 		-w 10

--- a/miniToolkit/miniKit.mel
+++ b/miniToolkit/miniKit.mel
@@ -1,6 +1,6 @@
 if(`window -ex miniKitWin`) deleteUI miniKitWin;
 
-$miniKitWindow = `window
+$miniKitWin = `window
 	-title "liquidbuddha.studios - miniKit"
 	-s 1
 	-w 10

--- a/miniToolkit/miniKit.mel
+++ b/miniToolkit/miniKit.mel
@@ -529,7 +529,7 @@ proc phi_creation(int $nCurves, float $sNode, float $pNode, int $pDepth, int $ph
 		xform -os -piv 0 0 0;
 		rename $phiGrp phiCurve_Grp;
 
-		rename $phiCurve phiCurveGrp_1;
+		rename $phiCurve "phiCurveGrp_1";
 		$phiCurve = "phiCurveGrp_1";
 	}
 

--- a/miniToolkit/miniKit.mel
+++ b/miniToolkit/miniKit.mel
@@ -529,7 +529,7 @@ proc phi_creation(int $nCurves, float $sNode, float $pNode, int $pDepth, int $ph
 		xform -os -piv 0 0 0;
 		rename $phiGrp phiCurve_Grp;
 
-		rename $phiCurve "phiCurveGrp_1";
+		rename $phiCurve phiCurveGrp_1;
 		$phiCurve = "phiCurveGrp_1";
 	}
 


### PR DESCRIPTION
Windows users have to use forward slashes in paths.
The object "lbs_scriptsWindow" couldn't be found because it was called "lbs_scriptsWin" (Using Maya 2012), the issue went away after rename.
